### PR TITLE
AK - reenable global interrupts

### DIFF
--- a/SK6812_io.cpp
+++ b/SK6812_io.cpp
@@ -140,4 +140,6 @@ w_nop16
   }
   
   SREG=sreg_prev;
+
+  sei();
 }


### PR DESCRIPTION
Fix global interrupt issue after writing out the led stream to the strip.